### PR TITLE
refactor:css

### DIFF
--- a/app/views/searches/saved.html.erb
+++ b/app/views/searches/saved.html.erb
@@ -1,4 +1,4 @@
-<div class="space-y-4 flex flex-col rounded-xl items-center sm:items-start pt-4 px-4 sm:px-0 bg-white/70 backdrop-blur-md">
+<div class="space-y-4 flex flex-col rounded-xl items-center pt-4 px-4 sm:px-0 bg-white/70 backdrop-blur-md">
   <h1 class="text-xl sm:text-2xl font-bold">保存済みレシピ一覧</h1>
   <p class="text-sm sm:text-base">保存されたレシピ数：<%= @saved_recipes.count %></p>
 


### PR DESCRIPTION
保存済みレシピ一覧画面で画面幅が640px以上になると'items-center'が無効化され、中央揃えが崩れる不具合。
'sm:items-start'の記述があり、これが原因かつ不要であったため削除。