### PR TITLE
fix:性別選択欄

### DIFF
--- a/app/views/searches/_ingredients_form.html.erb
+++ b/app/views/searches/_ingredients_form.html.erb
@@ -16,7 +16,10 @@
               <div>
                 <%= bf.label key, label, class: "block text-gray-700 font-medium mb-1 text-sm" %>
                 <% if key == :gender %>
-                  <%= bf.select key, [["男性", "male"], ["女性", "female"]], selected: current_user&.gender, class: "w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-blue-500 focus:border-blue-500" %>
+                  <%= bf.select key,
+                    [["指定しない", "Unspecified"], ["男性", "male"], ["女性", "female"]],
+                    { selected: current_user&.gender.presence || "Unspecified" },
+                    class: "w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-blue-500 focus:border-blue-500" %>
                 <% else %>
                   <%= bf.number_field key, min: 0, value: current_user&.send(key), class: "w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-blue-500 focus:border-blue-500" %>
                 <% end %>


### PR DESCRIPTION
レシピ検索画面でのユーザー性別欄が男性or女性しか選択できなかったため、`指定しない`を選択肢に追加。